### PR TITLE
Small fixes to the powershell scripts 

### DIFF
--- a/terraform/Set-LoadTestEnv.ps1
+++ b/terraform/Set-LoadTestEnv.ps1
@@ -32,8 +32,9 @@ foreach ($Line in $FileContent) {
     }
     
     # Set the environment variable for the current process
-    [System.Environment]::SetEnvironmentVariable($VarName, $VarValue, [System.EnvironmentVariableTarget]::Process)
+    Set-Variable -Name $VarName -Value $VarValue
     Write-Host "Exported: $VarName=$VarValue"
+
 }
 
 Write-Host "Environment variables from $EnvFile have been loaded."

--- a/terraform/Setup-LoadTest.ps1
+++ b/terraform/Setup-LoadTest.ps1
@@ -15,17 +15,13 @@ if (-Not (Test-Path -Path $VariablesFile)) {
 # Source the variables and verify they are loaded
 Write-Host "`n💾 Loading configuration from $VariablesFile..."
 . $VariableScript
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "`n❌ Error: Failed to load variables from $VariablesFile"
-    exit 1
-}
 
 # Check if the Azure CLI load testing extension is installed
 Write-Host "`n🔍 Checking for Azure CLI load testing extension..."
 $ExtensionInstalled = az extension list | ConvertFrom-Json | Where-Object { $_.name -eq "load-testing" }
 if (-Not $ExtensionInstalled) {
     Write-Host "Installing Azure CLI load testing extension..."
-    az extension add -n load-testing
+    az extension add -n load
 }
 
 # Get current subscription ID

--- a/terraform/setup_load_test.sh
+++ b/terraform/setup_load_test.sh
@@ -22,7 +22,7 @@ echo
 echo "🔍 Checking for Azure CLI load testing extension..."
 if ! az extension list | grep -q "load"; then
   echo "Installing Azure CLI load testing extension..."
-  az extension add -n load-testing
+  az extension add -n load
 fi
 
 # Get current subscription ID


### PR DESCRIPTION
- Fix the way the environment variables are set
- Remove the check of the $LASTEXITCODE. This is not working as intended, we can change it to make it work but I believe it is not necessary. 
- Fix the name of the az cli extension